### PR TITLE
Définition des types et interfaces pour les données olympiques

### DIFF
--- a/src/app/core/models/Olympic.ts
+++ b/src/app/core/models/Olympic.ts
@@ -1,9 +1,7 @@
-// TODO: create here a typescript interface for an olympic country
-/*
-example of an olympic country:
-{
-    id: 1,
-    country: "Italy",
-    participations: []
+import { Participation } from './Participation';
+
+export interface Olympic {
+  id: number;
+  country: string;
+  participations: Participation[];
 }
-*/

--- a/src/app/core/models/Participation.ts
+++ b/src/app/core/models/Participation.ts
@@ -1,11 +1,7 @@
-// TODO: create here a typescript interface for a participation
-/*
-example of participation:
-{
-    id: 1,
-    year: 2012,
-    city: "Londres",
-    medalsCount: 28,
-    athleteCount: 372
+export interface Participation {
+  id: number;
+  year: number;
+  city: string;
+  medalsCount: number;
+  athleteCount: number;
 }
-*/

--- a/src/app/core/services/olympic.service.ts
+++ b/src/app/core/services/olympic.service.ts
@@ -1,15 +1,15 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
+import { Olympic } from '../models/Olympic';
 
 @Injectable({
   providedIn: 'root',
 })
 export class OlympicService {
   private olympicUrl = './assets/mock/olympic.json';
-  private olympics$ = new BehaviorSubject<any>(undefined);
-
+  private olympics$ = new BehaviorSubject<Olympic[] | null>(null);
   constructor(private http: HttpClient) {}
 
   loadInitialData() {
@@ -25,7 +25,7 @@ export class OlympicService {
     );
   }
 
-  getOlympics() {
+  getOlympics(): Observable<Olympic[] | null> {
     return this.olympics$.asObservable();
   }
 }

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Observable, of } from 'rxjs';
+import { Olympic } from 'src/app/core/models/Olympic';
 import { OlympicService } from 'src/app/core/services/olympic.service';
 
 @Component({
@@ -8,11 +9,13 @@ import { OlympicService } from 'src/app/core/services/olympic.service';
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
-  public olympics$: Observable<any> = of(null);
+  public olympics$: Observable<Olympic[] | null>;
 
-  constructor(private olympicService: OlympicService) {}
+  constructor(private olympicService: OlympicService) {
+    this.olympics$ = this.olympicService.getOlympics();
+  }
 
   ngOnInit(): void {
-    this.olympics$ = this.olympicService.getOlympics();
+    //Les données sont chargées dans AppComponent
   }
 }


### PR DESCRIPTION
Cette PR ajoute les définitions des types et interfaces pour les données afin de typer correctement les données utilisées dans l'application.

Modification des fichiers de modèles Typescript pour les données.
Définition des Interfaces pour les données des médailles et des pays.

Fichiers concernés:
src/app/core/models/Olympic.ts 
src/app/core/models/Participation.ts 
src/app/core/services/olympic.service.ts 
src/app/pages/home/home.component.ts
